### PR TITLE
Lock Listen dependency to 3.0.6 to support Ruby 1.9.3

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -1,6 +1,7 @@
 ## HEAD
 
   * Test against Jekyll 2 and 3. (#30)
+  * Lock to Listen 3.0.6
 
 ## 1.3.0 / 2015-09-23
 

--- a/jekyll-watch.gemspec
+++ b/jekyll-watch.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "listen", "~> 3.0"
+  spec.add_runtime_dependency "listen", "3.0.6"
 
   require 'rbconfig'
   if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/

--- a/jekyll-watch.gemspec
+++ b/jekyll-watch.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "listen", "3.0.6"
+  spec.add_runtime_dependency "listen", "~> 3.0.6"
 
   require 'rbconfig'
   if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/


### PR DESCRIPTION
/domain @swhinnem @samandmoore 
/platform @samandmoore 

Listen 3.1.0 removed support for all Rubies less than 2.2, so we need
to lock down to the older version to support the Ruby we use (1.9.3)
